### PR TITLE
Server farm location is hardcoded.

### DIFF
--- a/template.json
+++ b/template.json
@@ -335,7 +335,7 @@
             "type": "Microsoft.Web/serverfarms",
             "apiVersion": "2022-03-01",
             "name": "[parameters('ServerFarm')]",
-            "location": "West Europe",
+            "location": "[parameters('NewOpenAIResourceLocation')]",
             "sku": {
                 "name": "B2",
                 "tier": "Basic",


### PR DESCRIPTION
hello team,

there is an issue with the template. If you choose a different location than westerneurope the deployment fails because the serverFarm has location harcoded to West Europe:

![image](https://user-images.githubusercontent.com/41587804/224989353-a32b51b8-baf1-4f49-85a8-3ff60fc03158.png)


I forked the repo and I have replaced "West Europe" with

[parameters('NewOpenAIResourceLocation')]

so that now it uses always the same location.